### PR TITLE
supporting inline sourcemaps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import ts = require('typescript');
 declare function tss(code: string, options: ts.CompilerOptions): string;
 declare module tss {
     class TypeScriptSimple {
+        private doSemanticChecks;
         private service;
         private outputs;
         private options;
@@ -11,16 +12,23 @@ declare module tss {
         /**
          * @param {ts.CompilerOptions=} options TypeScript compile options (some options are ignored)
          */
-        constructor(options?: ts.CompilerOptions);
+        constructor(options?: ts.CompilerOptions, doSemanticChecks?: boolean);
         /**
          * @param {string} code TypeScript source code to compile
-         * @return {string}
+         * @param {string} only needed if you plan to use sourceMaps. Provide the complete filePath relevant to you
+         * @return {string} The JavaScript with inline sourceMaps if sourceMaps were enabled
          */
-        compile(code: string): string;
+        compile(code: string, filename?: string): string;
         private createService();
         private getTypeScriptBinDir();
         private getDefaultLibFilename(options);
-        private toJavaScript(service);
+        /**
+         * converts {"version":3,"file":"file.js","sourceRoot":"","sources":["file.ts"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,MAAM,CAAC"}
+         * to {"version":3,"sources":["foo/test.ts"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,MAAM,CAAC","file":"foo/test.ts","sourcesContent":["var x = 'test';"]}
+         * derived from : https://github.com/thlorenz/convert-source-map
+         */
+        private getInlineSourceMap(mapText, filename);
+        private toJavaScript(service, filename?);
         private formatDiagnostics(diagnostics);
     }
 }

--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ var tss;
             this.outputs = {};
             this.files = {};
             if (options.target == null) {
-                options.target = ts.ScriptTarget.ES5;
+                options.target = 1 /* ES5 */;
             }
             if (options.module == null) {
-                options.module = ts.ModuleKind.None;
+                options.module = 0 /* None */;
             }
             this.options = options;
         }
@@ -81,7 +81,7 @@ var tss;
             return path.dirname(require.resolve('typescript'));
         };
         TypeScriptSimple.prototype.getDefaultLibFilename = function (options) {
-            if (options.target === ts.ScriptTarget.ES6) {
+            if (options.target === 2 /* ES6 */) {
                 return 'lib.es6.d.ts';
             }
             else {
@@ -105,7 +105,7 @@ var tss;
             if (filename === void 0) { filename = FILENAME_TS; }
             var output = service.getEmitOutput(FILENAME_TS);
             // Meaning of succeeded is driven by whether we need to check for semantic errors or not
-            var succeeded = output.emitOutputStatus === ts.EmitReturnStatus.Succeeded;
+            var succeeded = output.emitOutputStatus === 0 /* Succeeded */;
             if (!this.doSemanticChecks) {
                 // We have an output. It implies syntactic success
                 if (!succeeded)

--- a/test/test.js
+++ b/test/test.js
@@ -75,4 +75,24 @@ describe('typescript-update', function() {
             assert.equal(tss.compile(src), expected);
         });
     });
+
+    context('semantic vs. syntactic errors', function() {
+        var tss;
+        beforeEach(function() {
+            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES5}, false);
+        });
+
+        it('semantic errors are ignored', function() {
+            var src = "var x: number = 'some string';";
+            var expected = "var x = 'some string';" + eol;
+            assert.equal(tss.compile(src), expected);
+        });
+
+        it('syntactic errors are not ignored', function() {
+            var src = "var x = 123 123;";
+            assert.throws(function() {
+                tss.compile(src);
+            }, /^Error: L1: ',' expected./);
+        });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var eol = require('os').EOL;
 
 var ts = require('typescript');
 var tss = require('../');
@@ -10,27 +11,27 @@ describe('typescript-update', function() {
     context('default target (ES5)', function() {
         it('compiles correct code', function() {
             var src = "var x: number = 1;";
-            var expected = 'var x = 1;\n';
+            var expected = 'var x = 1;' + eol;
             assert.equal(tss(src), expected);
         });
 
         it('does not replace CRLF literal', function() {
             var src = "var x: string = '\\r\\n';";
-            var expected = "var x = '\\r\\n';\n";
+            var expected = "var x = '\\r\\n';" + eol;
             assert.equal(tss(src), expected);
         });
 
         it('compiles many times', function() {
             var src = "var x: number = 1;";
-            var expected = 'var x = 1;\n';
+            var expected = 'var x = 1;' + eol;
             assert.equal(tss(src), expected);
 
             src = "var y: number = 2;";
-            expected = 'var y = 2;\n';
+            expected = 'var y = 2;' + eol;
             assert.equal(tss(src), expected);
 
             src = "var z: number = 3;";
-            expected = 'var z = 3;\n';
+            expected = 'var z = 3;' + eol;
             assert.equal(tss(src), expected);
         });
 
@@ -64,13 +65,13 @@ describe('typescript-update', function() {
 
         it('compiles ES6 "let"', function() {
             var src = "let x: number = 1;";
-            var expected = 'let x = 1;\n';
+            var expected = 'let x = 1;' + eol;
             assert.equal(tss.compile(src), expected);
         });
 
         it('compiles ES6 Promise', function() {
-            var src = "var x = new Promise(function (resolve, reject) {\n});";
-            var expected = src + '\n';
+            var src = "var x = new Promise(function (resolve, reject) {" + eol + "});";
+            var expected = src + eol;
             assert.equal(tss.compile(src), expected);
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -95,4 +95,20 @@ describe('typescript-update', function() {
             }, /^Error: L1: ',' expected./);
         });
     });
+
+    context('sourceMaps', function() {
+        var tss;
+        beforeEach(function() {
+            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES5, sourceMap: true}, false);
+        });
+
+        it('sourceMap:true should result in inline sourceMaps', function() {
+            var src = 'var x = "test";';
+            var srcFile = 'foo/test.ts';
+            var expected =
+                'var x = "test";' + eol
+                + '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZm9vL3Rlc3QudHMiLCJzb3VyY2VzIjpbImZvby90ZXN0LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLElBQUksQ0FBQyxHQUFHLE1BQU0sQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbInZhciB4ID0gXCJ0ZXN0XCI7Il19';
+            assert.equal(tss.compile(src, srcFile), expected);
+        });
+    });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
-        "declaration": false,
-        "noImplicitAny": false,
+        "declaration": true,
+        "noImplicitAny": true,
         "removeComments": false,
         "noLib": false
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.4.1",
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": false,
+        "noImplicitAny": false,
+        "removeComments": false,
+        "noLib": false
+    },
+    "filesGlob": [
+        "./**/*.ts",
+        "!./node_modules/**/*.ts"
+    ],
+    "files": [
+        "./index.d.ts",
+        "./index.ts",
+        "./typings/bundle.d.ts",
+        "./typings/node/node.d.ts"
+    ]
+}


### PR DESCRIPTION
closes https://github.com/teppeis/typescript-simple/issues/6

* [x] Passing tests
* [x] Add inline-sourcemaps

:+1: on your code quality. Really simple. Zero dependencies. Really easy to reuse. Comes with tests :heart: 

Added a `tsconfig.json` to make it easier to work on this with any editor. 
Will be bringing in stuff from https://github.com/thlorenz/convert-source-map
Will leave a comment once this code is ready for merge