### PR TITLE
tss second parameter "options" marked as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import ts = require('typescript');
-declare function tss(code: string, options: ts.CompilerOptions): string;
+declare function tss(code: string, options?: ts.CompilerOptions): string;
 declare namespace tss {
     class TypeScriptSimple {
         private doSemanticChecks;

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import ts = require('typescript');
 
 var FILENAME_TS = 'file.ts';
 
-function tss(code: string, options: ts.CompilerOptions): string {
+function tss(code: string, options?: ts.CompilerOptions): string {
     if (options) {
         return new tss.TypeScriptSimple(options).compile(code);
     } else {


### PR DESCRIPTION
Currently I am calling tss function with just one parameter and this is reported as an error by TypeScript compiler. This PR improves tss declaration to accept just one parameter.