### PR TITLE
Fix the error when outDir compiler option is specified

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -140,7 +140,8 @@ namespace tss {
                 throw new Error(this.formatDiagnostics(allDiagnostics));
             }
 
-            var outputFileName = FILENAME_TS.replace(/ts$/, 'js');
+            var outDir = 'outDir' in this.options ? this.options.outDir : '.';
+            var outputFileName = path.join(outDir, FILENAME_TS.replace(/ts$/, 'js'));
             var file = output.outputFiles.filter((file) => file.name === outputFileName)[0];
             var text = file.text;
 

--- a/test/test.js
+++ b/test/test.js
@@ -136,4 +136,18 @@ describe('typescript-update', function() {
             assert.equal(tss.compile(src, srcFile), expected);
         });
     });
+
+    context('tss outDir option is specified', function() {
+        var tss;
+        beforeEach(function() {
+            tss = new TypeScriptSimple({outDir: 'built/'}, false);
+        });
+
+        it('compares output file names with the name with outDir', function() {
+            var src = "var x = 123;";
+            assert.doesNotThrow(function() {
+                tss.compile(src);
+            }, /Cannot read property 'text'/);
+        });
+    });
 });


### PR DESCRIPTION
If `outDir` compiler option is specified, `tss` throws:

```
/.../node_modules/espower-typescript/node_modules/typescript-simple/index.js:135
            var text = file.text;
                           ^

TypeError: Cannot read property 'text' of undefined
```

Because TypeScript LS emits `outputFiles` consists of the files prefixed with `outDir` (e.g. `built/file.js`), so `outputFiles` never contain `file.js`.

Note:

This error encountered while I try to use espower-typescript.