### PR TITLE
fix contstructor to handle null options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ namespace tss {
          * @constructor
          */
         constructor(options: ts.CompilerOptions = {}, private doSemanticChecks = true) {
+            options = options || {};
             if (options.target == null) {
                 options.target = ts.ScriptTarget.ES5;
             }


### PR DESCRIPTION
- possible that user may give null in options parameter in constructor
- for example, no `tsconfig.json` file when using `espower-typescript`

when using [espower-typescript](https://github.com/power-assert-js/espower-typescript) as `mocha` compiler, there is an error about `options` parameter in constructor is null.

```
./node_modules/espower-typescript/node_modules/typescript-simple/index.js:29
            if (options.target == null) {
                       ^

TypeError: Cannot read property 'target' of null
```

after a few tests, I found that could happen when I remove the tsconfig.json file.

for evaluating undefined and null, I make this [test](http://www.typescriptlang.org/Playground#src=function%20a(str%3A%20string%20%3D%20%22%22)%3A%20string%20%7B%0A%09return%20str%3B%0A%7D%0A%0Aalert(a())%3B%0Aalert(a(null))%3B%0Aalert(a(%22aa%22))%3B%0A) in Typescript playground