### PR TITLE
Fix TypeError: Cannot read property 'text' of undefined error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare namespace tss {
         private createService();
         private getTypeScriptBinDir();
         private getDefaultLibFileName(options);
+        private getFile(outputFiles, fileName);
         private toJavaScript(service, fileName);
         private normalizeSlashes(path);
         private formatDiagnostics(diagnostics);

--- a/index.ts
+++ b/index.ts
@@ -142,6 +142,10 @@ namespace tss {
             return JSON.stringify(sourceMap);
         }
 
+        private getFile (outputFiles: ts.OutputFile[], fileName: string): ts.OutputFile {
+            return outputFiles.filter((file) => file.name === fileName)[0]
+        }
+
         private toJavaScript(service: ts.LanguageService, fileName: string): string {
             let output = service.getEmitOutput(fileName);
 
@@ -166,13 +170,13 @@ namespace tss {
             }
             // for Windows #37
             outputFileName = this.normalizeSlashes(outputFileName);
-            let file = output.outputFiles.filter((file) => file.name === outputFileName)[0];
+            let file = this.getFile(output.outputFiles, outputFileName);
             let text = file.text;
 
             // If we have sourceMaps convert them to inline sourceMaps
             if (this.options.sourceMap) {
                 let sourceMapFileName = outputFileName + '.map';
-                let sourceMapFile = output.outputFiles.filter((file) => file.name === sourceMapFileName)[0];
+                let sourceMapFile = this.getFile(output.outputFiles, sourceMapFileName)
 
                 // Transform sourcemap
                 let sourceMapText = sourceMapFile.text;

--- a/index.ts
+++ b/index.ts
@@ -143,7 +143,11 @@ namespace tss {
         }
 
         private getFile (outputFiles: ts.OutputFile[], fileName: string): ts.OutputFile {
-            return outputFiles.filter((file) => file.name === fileName)[0]
+            const files = outputFiles.filter((file) => {
+              const full = path.resolve(process.cwd(), fileName);
+              return file.name === fileName || file.name === full;
+            });
+            return files[0];
         }
 
         private toJavaScript(service: ts.LanguageService, fileName: string): string {


### PR DESCRIPTION

## TL;DR

Fix `TypeError: Cannot read property 'text' of undefined` error.

## Detail

When importing `relative path` like following, `typescript-simple` raised exception.

- <https://github.com/9renpoto/ts/blob/fix/filename/test/index.test.ts#L1>

    ```
    TypeError: Cannot read property 'text' of undefined
        at TypeScriptSimple.toJavaScript (/tmp/src/ts/node_modules/typescript-simple/index.js:162:28)
        at TypeScriptSimple.compile (/tmp/src/ts/node_modules/typescript-simple/index.js:71:25)
        at Object.loadTypeScript (/tmp/src/ts/node_modules/espower-typescript/index.js:19:22)
    ```

### Actual behavior

`service.getEmitOutput(fileName)` returns `relative path` and `absorute path`.

eg.
\#: see also https://github.com/power-assert-js/espower-typescript/issues/16#issue-149396537
    
/tmp/src/sample/test.ts

```typescript
import {test} from './dep'

test()
```
    
/tmp/src/sample/dep.ts


```typescript
export function test() {
    console.log('from ts')
}
```

- `service.getEmitOutput('test.ts')` returns `relative path`
    - `test.js`
- `service.getEmitOutput('dep.ts')` returns `absolute path`
    - `/tmp/src/sample/deps.js`
    
So, [this line](https://github.com/teppeis/typescript-simple/blob/master/index.ts#L169) compared relative path(`outputFileName`) with absolute path(`file.name`) and returns `undefined`.

## Solution

Convert `relative path` to `absolute path`.

## PoC

Please see our sample project.

1. git clone https://github.com/9renpoto/ts.git
1. git checkout fix/filename
1. npm install
1. npm test

\# note

`package.json`'s `typescript-simple` pointed to our PR branch.

If you delete this line, exception would raised.

## Misc

This PR would also solve following issue.

- <https://github.com/power-assert-js/espower-typescript/issues/16>

Please check and include this PR. 

Thank you.