### PR TITLE
bump to v6.0 with typescript v2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 node_modules
 index.js
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Simple API to compile TypeScript code string to JavaScript. That's all!
 * typescript-simple v3.x.x uses TypeScript v1.6
 * typescript-simple v4.x.x uses TypeScript v1.7
 * typescript-simple v5.x.x uses TypeScript v1.8
+* typescript-simple v6.x.x uses TypeScript v2.0
 
 Note: typescript-simple updates the major version for TypeScript's minor update including breaking changes.
 

--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,9 @@ function tss(code: string, options?: ts.CompilerOptions): string {
 namespace tss {
     export class TypeScriptSimple {
         private service: ts.LanguageService = null;
-        private outputs: ts.Map<string> = {};
+        private outputs: ts.Map<string> = {} as ts.Map<string>;
         private options: ts.CompilerOptions;
-        private files: ts.Map<{ version: number; text: string; }> = {};
+        private files: ts.Map<{ version: number; text: string; }> = {} as ts.Map<{ version: number; text: string; }>;
 
         /**
          * @param {ts.CompilerOptions=} options TypeScript compile options (some options are ignored)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-simple",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Simple API to compile TypeScript code string to JavaScript. That's all!",
   "main": "index.js",
   "engines": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/teppeis/typescript-simple",
   "dependencies": {
-    "typescript": "^1.8.2"
+    "typescript": "^2.0.3"
   },
   "devDependencies": {
     "mocha": "^2.4.5"


### PR DESCRIPTION
Hello, 

typescript-simple is what I need with my project, please upgrade to typescript v2.0 so I could use it directly with `npm install`.

thanks!