### PR TITLE
chore(package): support TypeScript v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.12"
   - "4"
-  - "stable"
+  - "6"
 sudo: false
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Simple API to compile TypeScript code string to JavaScript. That's all!
 * typescript-simple v3.x.x uses TypeScript v1.6
 * typescript-simple v4.x.x uses TypeScript v1.7
 * typescript-simple v5.x.x uses TypeScript v1.8
+* typescript-simple v6.x.x uses TypeScript v2.0
 
 Note: typescript-simple updates the major version for TypeScript's minor update including breaking changes.
 
@@ -147,7 +148,7 @@ MIT License: Teppei Sato &lt;teppeis@gmail.com&gt;
 [travis-url]: https://travis-ci.org/teppeis/typescript-simple
 [deps-image]: https://img.shields.io/david/teppeis/typescript-simple.svg
 [deps-url]: https://david-dm.org/teppeis/typescript-simple
-[node-version]: https://img.shields.io/badge/Node.js%20support-v0.12–v5-brightgreen.svg
+[node-version]: https://img.shields.io/badge/Node.js%20support-v0.12–v6-brightgreen.svg
 [coverage-image]: https://img.shields.io/coveralls/teppeis/typescript-simple/master.svg
 [coverage-url]: https://coveralls.io/github/teppeis/typescript-simple?branch=master
 [license]: https://img.shields.io/npm/l/typescript-simple.svg

--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,9 @@ function tss(code: string, options?: ts.CompilerOptions): string {
 namespace tss {
     export class TypeScriptSimple {
         private service: ts.LanguageService = null;
-        private outputs: ts.Map<string> = {};
+        private outputs: ts.Map<string> = {} as ts.Map<string>;
         private options: ts.CompilerOptions;
-        private files: ts.Map<{ version: number; text: string; }> = {};
+        private files: ts.Map<{ version: number; text: string; }> = {} as ts.Map<{ version: number; text: string; }>;
 
         /**
          * @param {ts.CompilerOptions=} options TypeScript compile options (some options are ignored)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "typescript": "^2.0.3"
   },
   "devDependencies": {
-    "mocha": "^2.4.5"
+    "mocha": "^3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/teppeis/typescript-simple",
   "dependencies": {
-    "typescript": "^1.8.2"
+    "typescript": "^2.0.3"
   },
   "devDependencies": {
     "mocha": "^2.4.5"


### PR DESCRIPTION
Fixes #39, #50, #51 and #54.
Also updates mocha (fixes #44, #45, #46, #52 and #53).

Still broken in Windows (#47)