### PR TITLE
chore(package): update TypeScript v2.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -118,10 +118,17 @@ namespace tss {
         }
 
         private getDefaultLibFileName(options: ts.CompilerOptions): string {
-            if (options.target === ts.ScriptTarget.ES6) {
-                return 'lib.es6.d.ts';
-            } else {
-                return 'lib.d.ts';
+            switch (options.target) {
+                case ts.ScriptTarget.ES2015:
+                    return 'lib.es6.d.ts';
+                case ts.ScriptTarget.ES2016:
+                    return 'lib.es2016.d.ts';
+                case ts.ScriptTarget.ES2017:
+                case ts.ScriptTarget.ESNext:
+                case ts.ScriptTarget.Latest:
+                    return 'lib.es2017.d.ts';
+                default:
+                    return 'lib.d.ts';
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/teppeis/typescript-simple",
   "dependencies": {
-    "typescript": "^2.0.3"
+    "typescript": "^2.1.4"
   },
   "devDependencies": {
     "mocha": "^3.1.2"

--- a/test/test.js
+++ b/test/test.js
@@ -49,16 +49,18 @@ describe('typescript-simple', function() {
             var src = "var x: number = 'str';";
             assert.throws(function() {
                 tss(src);
-            }, /^Error: L0: Type 'string' is not assignable to type 'number'./);
+            // TypeScript 2.1 bug?
+            // }, /^Error: L0: Type 'string' is not assignable to type 'number'./);
+            }, /^Error: L0: Type '"str"' is not assignable to type 'number'./);
         });
 
-        it('compiles ES6 "let" to "var"', function() {
+        it('compiles ES2015 "let" to "var"', function() {
             var src = 'let x: number = 1;';
             var expected = 'var x = 1;' + eol;
             assert.equal(tss(src), expected);
         });
 
-        it('throws an error for ES6 Promise', function() {
+        it('throws an error for ES2015 Promise', function() {
             var src = "var x = new Promise(function (resolve, reject) {\n});";
             assert.throws(function() {
                 tss(src);
@@ -66,19 +68,19 @@ describe('typescript-simple', function() {
         });
     });
 
-    context('target ES6', function() {
+    context('target ES2015', function() {
         var tss;
         beforeEach(function() {
-            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES6});
+            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES2015});
         });
 
-        it('compiles ES6 "let" to "let"', function() {
+        it('compiles ES2015 "let" to "let"', function() {
             var src = "let x: number = 1;";
             var expected = 'let x = 1;' + eol;
             assert.equal(tss.compile(src), expected);
         });
 
-        it('does not throw for ES6 Promise', function() {
+        it('does not throw for ES2015 Promise', function() {
             var src = "var x = new Promise(function (resolve, reject) {" + eol + "});";
             var expected = src + eol;
             assert.equal(tss.compile(src), expected);

--- a/test/test.js
+++ b/test/test.js
@@ -66,6 +66,20 @@ describe('typescript-simple', function() {
                 tss(src);
             }, /^Error: L0: Cannot find name 'Promise'./);
         });
+
+        it('throws an error for ES2016 Array#includes', function() {
+            var src = "var x = [1, 2, 3].includes(2);";
+            assert.throws(function() {
+                tss(src);
+            }, /^Error: L0: Property 'includes' does not exist on type 'number\[]'./);
+        });
+
+        it('throws an error for ES2017 Object#values', function() {
+            var src = "var x = Object.values({});";
+            assert.throws(function() {
+                tss(src);
+            }, /^Error: L0: Property 'values' does not exist on type 'ObjectConstructor'./);
+        });
     });
 
     context('target ES2015', function() {
@@ -82,6 +96,32 @@ describe('typescript-simple', function() {
 
         it('does not throw for ES2015 Promise', function() {
             var src = "var x = new Promise(function (resolve, reject) {" + eol + "});";
+            var expected = src + eol;
+            assert.equal(tss.compile(src), expected);
+        });
+    });
+
+    context('target ES2016', function() {
+        var tss;
+        beforeEach(function() {
+            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES2016});
+        });
+
+        it('compiles ES2016 Array#includes', function() {
+            var src = "var x = [1, 2, 3].includes(2);";
+            var expected = src + eol;
+            assert.equal(tss.compile(src), expected);
+        });
+    });
+
+    context('target ES2017', function() {
+        var tss;
+        beforeEach(function() {
+            tss = new TypeScriptSimple({target: ts.ScriptTarget.ES2017});
+        });
+
+        it('throws an error for ES2017 Object#values', function() {
+            var src = "var x = Object.values({});";
             var expected = src + eol;
             assert.equal(tss.compile(src), expected);
         });


### PR DESCRIPTION
- `ScriptTarget.ES6` is renamed to `ES2015`
- `ES2016`, `ES2017` and `ESNext` are added
- `lib.*.d.ts` are added

https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript
https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes
https://github.com/Microsoft/TypeScript/wiki/API-Breaking-Changes