### PR TITLE
strictNullChecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 node_modules
 index.js
+npm-debug.log

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ function tss(code: string, options?: ts.CompilerOptions): string {
 
 namespace tss {
     export class TypeScriptSimple {
-        private service: ts.LanguageService = null;
+        private service: ts.LanguageService | null = null;
         private outputs: ts.Map<string> = {} as ts.Map<string>;
         private options: ts.CompilerOptions;
         private files: ts.Map<{ version: number; text: string; }> = {} as ts.Map<{ version: number; text: string; }>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "declaration": true,
         "noImplicitAny": true,
+        "strictNullChecks": true,
         "removeComments": false,
         "stripInternal": true,
         "noLib": false


### PR DESCRIPTION
This PR enables typescript-simple to be consumed by TypeScript projects which use `strictNullChecks` option.

I modified one type to be compatible with this option.
I also turned this option on for typescript-simple itself to ensure that it stays compatible with this option in the future.
