### PR TITLE
Flatten chained error messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -178,7 +178,7 @@ namespace tss {
                 throw new Error(this.formatDiagnostics(allDiagnostics));
             }
 
-            let outDir = 'outDir' in this.options ? this.options.outDir : '';
+            let outDir = this.options.outDir != null ? this.options.outDir : '';
             let fileNameWithoutRoot = 'rootDir' in this.options ? fileName.replace(new RegExp('^' + this.options.rootDir), '') : fileName;
             let outputFileName: string;
             if (this.options.jsx === ts.JsxEmit.Preserve) {
@@ -213,11 +213,9 @@ namespace tss {
 
         private formatDiagnostics(diagnostics: ts.Diagnostic[]): string {
             return diagnostics.map((d) => {
-                if (d.file) {
-                    return 'L' + d.file.getLineAndCharacterOfPosition(d.start).line + ': ' + d.messageText;
-                } else {
-                    return d.messageText;
-                }
+                const message = ts.flattenDiagnosticMessageText(d.messageText, os.EOL);
+                return d.file ? 'L' + d.file.getLineAndCharacterOfPosition(d.start).line + ': ' + message
+                              : message;
             }).join(os.EOL);
         }
     }


### PR DESCRIPTION
The confusingly named `messageText` property of `Diagnostic` has the type `string | DiagnosticMessageChain`. That is, it could be a message, or a chain of error messages (which happens if you have an error nested in a type somewhere.

Previously, if an error had a message chain, the output was something like `L123 [Object object]`. This changes it to use the method `ts.flattenDiagnosticMessageText` which does exactly what you'd hope.

_Small additional change_: I don't know if it was just my own settings, but TypeScript was complaining about the line `'outDir' in this.options ? this.options.outDir : ''` since it wasn't narrowing the type from `string | undefined`. I changed the condition and it seemed happier then.