### PR TITLE
Fixes TypeError: Cannot read property 'text' of undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare namespace tss {
         private doSemanticChecks;
         private service;
         private options;
+        private compilerHost;
         private files;
         /**
          * @param {ts.CompilerOptions=} options TypeScript compile options (some options are ignored)
@@ -24,6 +25,8 @@ declare namespace tss {
         private getTypeScriptBinDir();
         private getDefaultLibFileName(options);
         private getFile(outputFiles, fileName);
+        private getEmulatedEmitHost(service);
+        private getSourceFilePathInNewDir(service, fileName);
         private toJavaScript(service, fileName);
         private normalizeSlashes(path);
         private formatDiagnostics(diagnostics);

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ namespace tss {
     export class TypeScriptSimple {
         private service: ts.LanguageService | null = null;
         private options: ts.CompilerOptions;
+        private compilerHost: ts.CompilerHost;
         private files: {[key: string]: { version: number; text: string; }} = {};
 
         /**
@@ -58,6 +59,10 @@ namespace tss {
 
             if (!this.service) {
                 this.service = this.createService();
+            }
+
+            if (!this.compilerHost) {
+                this.compilerHost = ts.createCompilerHost(this.options);
             }
 
             let file = this.files[fileName];
@@ -164,6 +169,37 @@ namespace tss {
             return files[0];
         }
 
+        private getEmulatedEmitHost(service: ts.LanguageService): any {
+            let program: any = service.getProgram();
+            return {
+                getCanonicalFileName: this.compilerHost.getCanonicalFileName,
+                getCommonSourceDirectory: program.getCommonSourceDirectory,
+                getCompilerOptions: program.getCompilerOptions,
+                getCurrentDirectory: ()=> process.cwd()
+            };
+        }
+
+        private getSourceFilePathInNewDir(service: ts.LanguageService, fileName: string): string {
+            let outputFileName: string;
+            // using secred function
+            let anonyTs = (<any>ts);
+            // check `getSourceFilePathInNewDir` deprecated
+            if (anonyTs.getSourceFilePathInNewDir && 'outDir' in this.options) {
+                outputFileName = anonyTs.getSourceFilePathInNewDir({fileName: fileName}, this.getEmulatedEmitHost(service), this.options.outDir);
+            } else {
+                let outDir = (this.options && this.options.outDir) ? this.options.outDir : '';
+                let fileNameWithoutRoot = 'rootDir' in this.options ? fileName.replace(new RegExp('^' + this.options.rootDir), '') : fileName;
+                outputFileName = path.join(outDir, fileNameWithoutRoot);
+            }
+
+            if (this.options.jsx === ts.JsxEmit.Preserve) {
+                outputFileName = outputFileName.replace(/\.tsx$/, '.jsx');
+            } else {
+                outputFileName = outputFileName.replace(/\.tsx?$/, '.js');
+            }
+            return outputFileName;
+        }
+
         private toJavaScript(service: ts.LanguageService, fileName: string): string {
             let output = service.getEmitOutput(fileName);
 
@@ -177,17 +213,11 @@ namespace tss {
             if (allDiagnostics.length) {
                 throw new Error(this.formatDiagnostics(allDiagnostics));
             }
+            let outputFileName = this.getSourceFilePathInNewDir(service, fileName);
 
-            let outDir = (this.options && this.options.outDir) ? this.options.outDir : '';
-            let fileNameWithoutRoot = 'rootDir' in this.options ? fileName.replace(new RegExp('^' + this.options.rootDir), '') : fileName;
-            let outputFileName: string;
-            if (this.options.jsx === ts.JsxEmit.Preserve) {
-                outputFileName = path.join(outDir, fileNameWithoutRoot.replace(/\.tsx$/, '.jsx'));
-            } else {
-                outputFileName = path.join(outDir, fileNameWithoutRoot.replace(/\.tsx?$/, '.js'));
-            }
             // for Windows #37
             outputFileName = this.normalizeSlashes(outputFileName);
+
             let file = this.getFile(output.outputFiles, outputFileName);
             if (output.outputFiles.length == 0) {
                 return '';

--- a/index.ts
+++ b/index.ts
@@ -189,6 +189,10 @@ namespace tss {
             // for Windows #37
             outputFileName = this.normalizeSlashes(outputFileName);
             let file = this.getFile(output.outputFiles, outputFileName);
+            if (output.outputFiles.length == 0) {
+                return '';
+            }
+
             let text = file.text;
 
             // If we have sourceMaps convert them to inline sourceMaps

--- a/test/test.js
+++ b/test/test.js
@@ -266,4 +266,23 @@ describe('typescript-simple', function() {
       assert.equal(tss.compile(src, path.join(__dirname, 'module.ts')), expected);
       assert.equal(tss.compile(src, path.join('test', 'module.ts')), expected);
     });
+
+    describe('declaration files', function(){
+      it('sould result is blank', function(){
+        var tss = new TypeScriptSimple({});
+        var src = "declare namespace github.api {}";
+        var expected = '';
+        assert.equal(tss.compile(src, path.join(__dirname, 'module.d.ts')), expected);
+        assert.equal(tss.compile(src, path.join('test', 'module.ts')), expected);
+      });
+      it('sould raised compile error with broken code', function(){
+        var tss = new TypeScriptSimple({});
+        var src = "declare namespace github.api {";
+        var expected = '';
+
+        assert.throws(function() {
+          tss.compile(src, 'module.d.ts');
+        });
+      });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -210,15 +210,20 @@ describe('typescript-simple', function() {
     });
 
     context('tss outDir and rootDir options are specified', function() {
-        var tss;
-        beforeEach(function() {
-            tss = new TypeScriptSimple({outDir: 'built/', rootDir: 'src'}, false);
-        });
 
-        it('compares output file names with the name with outDir without rootDir', function() {
+        it('compares output file names with the name with outDir and rootDir', function() {
+            var tss = new TypeScriptSimple({outDir: 'built/', rootDir: 'src'}, false);
             var src = "var x = 123;";
             assert.doesNotThrow(function() {
                 tss.compile(src, 'src/file.ts');
+            });
+        });
+
+        it('compares output file names with the name with outDir and rootDir and called convertCompilerOptionsFromJson options', function() {
+            var tss = new TypeScriptSimple(ts.convertCompilerOptionsFromJson({outDir: 'built/', rootDir: 'src/'}, process.cwd()).options, false);
+            var src = "var x = 123;";
+            assert.doesNotThrow(function() {
+              tss.compile(src, 'src/file.ts');
             });
         });
     });


### PR DESCRIPTION
this pr is trying to resolve https://github.com/teppeis/typescript-simple/issues/68

## commit 1:  d.ts files support

[service.getEmitOutput(fileName)](https://github.com/teppeis/typescript-simple/blob/v8.0.0/index.ts#L168) do not generate file from `.d.ts`.
Then `output.outputFiles` is empty.

I changed if output.outputFiles is empty it will return blank text. > ~~6e03da866dd0f3c3f9ffd159189aa8c9ec19a17e~~ 8a84245


## commit 2: AbsolutePath rootDir / outDir support

Error caused by ts.convertCompilerOptionsFromJson created compilerOption.
for example) https://github.com/power-assert-js/espower-typescript/blob/v8.0.0/index.js#L35

convertCompilerOptionsFromJson convert member of path to absolutely.

for example)
```json
// before
// "cwd": "/project/source/path"
{
  "rootDir": "src",
  "outDir": "dist"
}
// after
{
  "rootDir": "/project/source/path/src",
  "outDir": "/project/source/path/dist"
}
```



I change generating process for comparing outputFileName.  ~~818cee5eac4857774fdc914a60c4aaea421dcff9~~ b94dd64

This process used and imported typescript internal function.
It means that functions do not declare in typescript.d.ts.
I am sorry to use it through any type ;(

